### PR TITLE
Add argv[1] to be `armed` as stated in README.md *minor change*

### DIFF
--- a/dpifw.py
+++ b/dpifw.py
@@ -9,7 +9,7 @@ import sys
 
 from netfilterqueue import NetfilterQueue
 
-ARMED = True if len(sys.argv) > 1 and sys.argv[1].lower() == "arm" else False
+ARMED = True if len(sys.argv) > 1 and sys.argv[1].lower() == "armed" else False
 BAD_PATTERNS ={
     "SSH": re.compile(b"SSH-2.0-OpenSSH_.+\r\n$"),
 }
@@ -30,7 +30,7 @@ def filter(pkt):
 
 if __name__ == "__main__":
     state = ARMED and "Armed" or "Disarmed"
-    print(f"\n--==] The Stunningly Shithouse DPI Firewall ]==--")
+    print(f"\n--==[ The Stunningly Shithouse DPI Firewall ]==--")
     print(f"     State: {state}. Listening for traffic...\n")
     nfqueue = NetfilterQueue()
     nfqueue.bind(1, filter)


### PR DESCRIPTION
I noticed that in README.md it said to run with the argument `armed` when the variable `ARMED` was only true if the argument alongside was `arm`, not `armed`. Judging from the name, this could of been a joke but if not merge for the benefit of your users.